### PR TITLE
Add general and starting stats to favorites page

### DIFF
--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,8 +1,55 @@
 <section class="champions">
+  <h2><%= current_user.name %>'s Favorites</h2>
   <% @champion_facade.favorites(current_user).each do |champ| %>
     <div class="champ">
       <h3><a href="/champions/<%= champ.name %>"><%= champ.name.titleize %>, <%= champ.title.titleize %></a></h3>
-      <p><a href="/my_favorites/<%= champ.id %>" data_method="delete">Unfollow</a></p>
+      <p><a href="/my_favorites/<%= champ.id %>" data_method="delete">Unfavorite</a></p>
+      <table class="stats">
+        <tbody>
+          <tr>
+            <td><h4>General Stats</h4></td>
+            <td></td>
+            <td><h4>Starting Stats</h4></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Attack:</td>
+            <td><%= champ.attack %></td>
+            <td>Attack Damage:</td>
+            <td><%= champ.attackDamage %></td>
+          </tr>
+          <tr>
+            <td>Defense:</td>
+            <td><%= champ.defense %></td>
+            <td>Health Points:</td>
+            <td><%= champ.hp %></td>
+          </tr>
+          <tr>
+            <td>Magic:</td>
+            <td><%= champ.magic %></td>
+            <td>Mana Points:</td>
+            <td><%= champ.mp %></td>
+          </tr>
+          <tr>
+            <td>Difficulty: </td>
+            <td><%= champ.difficulty %></td>
+            <td>Armor: </td>
+            <td><%= champ.armor %></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td>Spell Block: </td>
+            <td><%= champ.spellBlock %></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td></td>
+            <td>Move Speed: </td>
+            <td><%= champ.moveSpeed %></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   <% end %>
 </section>

--- a/spec/features/user_favorites_champion_spec.rb
+++ b/spec/features/user_favorites_champion_spec.rb
@@ -4,33 +4,35 @@ describe 'User Favorites a Champion' do
 
   before(:each) do
     file = File.open('./db/champ_data.json').read
-    champ = JSON.parse(file)[0]
-    @champion = Champion.create({
-      attack: champ["Attack"],
-      defense: champ["Defense"],
-      magic: champ["Magic"],
-      difficulty: champ["Difficulty"],
-      hp: champ["Hp"],
-      hpUpPerLevel: champ["HpUpPerLevel"],
-      mp: champ["Mp"],
-      mpUpPerLevel: champ["MpUpPerLevel"],
-      moveSpeed: champ["MoveSpeed"],
-      armor: champ["Armor"],
-      armorPerLevel: champ["ArmorPerLevel"],
-      spellBlock: champ["SpellBlock"],
-      spellBlockPerLevel: champ["SpellBlockPerLevel"],
-      attackRange: champ["AttackRange"],
-      hpRegen: champ["HpRegen"],
-      hpRegenPerLevel: champ["HpRegenPerLevel"],
-      mpRegen: champ["MpRegen"],
-      mpRegenPerLevel: champ["MpRegenPerLevel"],
-      attackDamage: champ["AttackDamage"],
-      attackDamagePerLevel: champ["AttackDamagePerLevel"],
-      attackSpeedOffset: champ["AttackSpeedOffset"],
-      championId: champ["ChampionId"],
-      name: champ["Name"].downcase,
-      title: champ["Title"].downcase
-    })
+    champs = JSON.parse(file)[0..5]
+    @champions = champs.map do |champ|
+      Champion.create({
+        attack: champ["Attack"],
+        defense: champ["Defense"],
+        magic: champ["Magic"],
+        difficulty: champ["Difficulty"],
+        hp: champ["Hp"],
+        hpUpPerLevel: champ["HpUpPerLevel"],
+        mp: champ["Mp"],
+        mpUpPerLevel: champ["MpUpPerLevel"],
+        moveSpeed: champ["MoveSpeed"],
+        armor: champ["Armor"],
+        armorPerLevel: champ["ArmorPerLevel"],
+        spellBlock: champ["SpellBlock"],
+        spellBlockPerLevel: champ["SpellBlockPerLevel"],
+        attackRange: champ["AttackRange"],
+        hpRegen: champ["HpRegen"],
+        hpRegenPerLevel: champ["HpRegenPerLevel"],
+        mpRegen: champ["MpRegen"],
+        mpRegenPerLevel: champ["MpRegenPerLevel"],
+        attackDamage: champ["AttackDamage"],
+        attackDamagePerLevel: champ["AttackDamagePerLevel"],
+        attackSpeedOffset: champ["AttackSpeedOffset"],
+        championId: champ["ChampionId"],
+        name: champ["Name"].downcase,
+        title: champ["Title"].downcase
+      })
+    end
     @user = User.create(name: "Bob", email: 'bob@bob.com', password: '0987654321', password_confirmation: '0987654321')
     visit '/login'
     fill_in 'Email', with: @user.email
@@ -39,22 +41,60 @@ describe 'User Favorites a Champion' do
   end
 
   it "They are taken to their favorites page" do
-    visit "/champions/#{@champion.name}"
+    visit "/champions/#{@champions[0].name}"
 
-    expect(page).to have_content("#{@champion.name.titleize}")
+    expect(page).to have_content("#{@champions[0].name.titleize}")
 
     click_on("Favorite")
 
     expect(current_path).to eq(my_favorites_path)
   end
 
+  it "they favorite more than one" do
+    visit "/champions/#{@champions[0].name}"
+    click_on("Favorite")
+    visit "/champions/#{@champions[1].name}"
+    click_on("Favorite")
+
+    expect(current_path).to eq(my_favorites_path)
+    expect(page).to have_css('.champ', count:2)
+  end
+
+  it "the stats for a champion are displayed on their favorites page" do
+    visit "/champions/#{@champions[0].name}"
+    click_on("Favorite")
+
+    within('.champ') do
+      expect(page).to have_content("Attack:")
+      expect(page).to have_content(@champions[0].attack)
+      expect(page).to have_content("Defense:")
+      expect(page).to have_content(@champions[0].defense)
+      expect(page).to have_content("Magic:")
+      expect(page).to have_content(@champions[0].magic)
+      expect(page).to have_content("Difficulty:")
+      expect(page).to have_content(@champions[0].difficulty)
+      expect(page).to have_content("Attack Damage:")
+      expect(page).to have_content(@champions[0].attackDamage)
+      expect(page).to have_content("Health Points:")
+      expect(page).to have_content(@champions[0].hp)
+      expect(page).to have_content("Mana Points:")
+      expect(page).to have_content(@champions[0].mp)
+      expect(page).to have_content("Armor:")
+      expect(page).to have_content(@champions[0].armor)
+      expect(page).to have_content("Spell Block:")
+      expect(page).to have_content(@champions[0].spellBlock)
+      expect(page).to have_content("Move Speed:")
+      expect(page).to have_content(@champions[0].moveSpeed)
+    end
+  end
+
   describe "Sad Paths" do
     it "They try to favorite a champion they already did" do
-      visit "/champions/#{@champion.name}"
+      visit "/champions/#{@champions[0].name}"
 
       click_on("Favorite")
 
-      visit "/champions/#{@champion.name}"
+      visit "/champions/#{@champions[0].name}"
 
       click_on("Favorite")
 


### PR DESCRIPTION
- [x] Wrote Tests
- [x] Implemented
- [x] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
* Adds general and starting stats for champions on my favorites page for quick access and comparison.
* closes #10 

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed